### PR TITLE
fix bug when node is null

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -65,7 +65,7 @@ function traverse(tree, cb) {
         for (let i = 0, l = tree.length; i < l; i++) {
             tree[i] = traverse(cb(tree[i]), cb);
         }
-    } else if (typeof tree === 'object' && tree.hasOwnProperty('content'))  traverse(tree.content, cb);
+    } else if (!!tree && typeof tree === 'object' && tree.hasOwnProperty('content'))  traverse(tree.content, cb);
     return tree;
 }
 


### PR DESCRIPTION
broken code:

```js
    tree.walk(function (node) {
        return null
    })
```

for reason that `typeof null === 'object' is true`