### PR TITLE
Fix true on booleans

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,6 @@
 {
     "eqeqeq": true,
+    "eqnull": true,
     "expr": true,
     "maxlen": 80,
     "undef": true,

--- a/lib/api.js
+++ b/lib/api.js
@@ -101,7 +101,7 @@ function compare(expected, actual) {
         if (typeof eo === 'object' && eo !== null && ao !== null)
             return compare(eo, ao);
         if (typeof eo === 'boolean')
-            return (eo && ao) || (!eo && !ao);
+            return eo !== (ao == null);
         return ao === eo;
     });
 }


### PR DESCRIPTION
Expressions like `{ attrs: { download: true }}` do not match elements like `<a href="..." download>` or `<a href="..." download="">`. It happens because empty string is falsy value (value that is converted to `false` with `ToBoolean`). This PR fixes this behaviour (and adds couple tests): only `null` and `undefined` are considered to be `false` (absent).