### PR TITLE
Lazy render as HTML

### DIFF
--- a/lib/posthtml.js
+++ b/lib/posthtml.js
@@ -11,6 +11,7 @@ function PostHTML(plugins) {
 
 /**
  * Parse html to json tree
+ *
  * @param {String} html htmltree
  * @returns {PostHTMLTree} json jsontree
  */
@@ -57,10 +58,7 @@ PostHTML.prototype.process = function(tree, options) {
             tree = result || tree;
         });
 
-        return {
-            html: render(tree, tree.options),
-            tree: tree
-        };
+        return lazyRender(tree);
     }
 
     // async mode
@@ -114,12 +112,8 @@ PostHTML.prototype.process = function(tree, options) {
 
     return new Promise(function(resolve, reject) {
         next(tree, function(err, tree) {
-            if (err) return reject(err);
-
-            resolve({
-                html: render(tree, tree.options),
-                tree: tree
-            });
+            if (err) reject(err);
+            else resolve(lazyRender(tree));
         });
     });
 };
@@ -156,4 +150,20 @@ function tryCatch(tryFn, catchFn) {
 function apiExtend(tree) {
     tree.walk = api.walk;
     tree.match = api.match;
+}
+
+/**
+ * Wraps tree in object with getter that renders it
+ * as HTML on demand.
+ *
+ * @param {PostHTMLTree} tree - json tree to wrap
+ * @returns {html: String, tree: PostHTMLTree} - result
+ */
+function lazyRender(tree) {
+    return {
+        get html() {
+            return render(tree, tree.options);
+        },
+        tree: tree
+    };
 }


### PR DESCRIPTION
Related to https://github.com/posthtml/posthtml/issues/102.

Motivation: sometimes (e.g. with custom renderer or recursive `<link rel=import>`) HTML string in result is not necessary. This PR defines `html` as a getter to avoid extra rendering with `posthtml-render`.