### PR TITLE
Make PostHTML#use method variadic

### DIFF
--- a/lib/posthtml.js
+++ b/lib/posthtml.js
@@ -20,11 +20,11 @@ PostHTML.parse = parser;
 /**
 * Use plugin
 *
-* @param {Function} plugin - PostHTML plugin to register
+* @param {...Function} plugin - PostHTML plugins to register
 * @returns {PostHTML}
 */
-PostHTML.prototype.use = function(plugin) {
-    this.plugins.push(plugin);
+PostHTML.prototype.use = function() {
+    [].push.apply(this.plugins, arguments);
     return this;
 };
 

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "jshint": "^2.8.0",
     "mocha": "^2.2.5",
     "mversion": "^1.10.0",
-    "object.assign": "^4.0.3",
-    "vow": "^0.4.12"
+    "object.assign": "^4.0.3"
   },
   "scripts": {
     "test": "npm run lint && mocha -R dot && npm run coverage",

--- a/test/api.js
+++ b/test/api.js
@@ -148,7 +148,6 @@ describe('API', function() {
                     tree.match(/<!--.*-->/g, function() {
                         return 'RegExp cool!';
                     });
-                    return tree;
                 }
             });
 


### PR DESCRIPTION
This PR improves API consistency with PostCSS and usefulness of `use` method. Also I have dropped `vow` from dependencies (it does not look very maintained) and used native methods (`setTimeout` to do the delay, `setImmediate` for task (`Promise.resolve` should do microtask)).