### PR TITLE
make parser configurable

### DIFF
--- a/lib/posthtml.js
+++ b/lib/posthtml.js
@@ -40,7 +40,7 @@ PostHTML.prototype.use = function() {
  */
 PostHTML.prototype.process = function(tree, options) {
     options = options || {};
-    var parser = options.parser || PostHTML.parse.bind(PostHTML)
+    var parser = options.parser || PostHTML.parse.bind(PostHTML);
     tree = options.skipParse ? tree : parser(tree);
     tree.options = options;
 

--- a/lib/posthtml.js
+++ b/lib/posthtml.js
@@ -32,6 +32,7 @@ PostHTML.prototype.use = function() {
  * @param {String|PostHTMLTree} tree - html/json tree
  * @param {?Object} options - Options object
  * @param {?Boolean} options.skipParse - to prevent parsing incoming tree
+ * @param {?Function} options.parser - alternate html parser to replace default
  * @param {?Boolean} options.sync - to run plugins synchronously, will throw
  *                                  if there are async plugins
  * @returns {Promise<{html: String, tree: PostHTMLTree}>|
@@ -39,7 +40,8 @@ PostHTML.prototype.use = function() {
  */
 PostHTML.prototype.process = function(tree, options) {
     options = options || {};
-    tree = options.skipParse ? tree : PostHTML.parse(tree);
+    var parser = options.parser || PostHTML.parse.bind(PostHTML)
+    tree = options.skipParse ? tree : parser(tree);
     tree.options = options;
 
     // sync mode


### PR DESCRIPTION
This would fix #137

I don't have a test written for this yet, because I'd need to write a little parser for the test, and want to make sure people are on board with this first. If they are, I'll write one.

Before making this happen, want to make sure that you guys are confident in the parser you are currently using, and that the API for `posthtml-parser` is fairly solid. Once this is done, next step seems to be documenting the parser's expected output so that people are able to write/add custom parsers.