### PR TITLE
Make code generator configurable

### DIFF
--- a/lib/posthtml.js
+++ b/lib/posthtml.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var parser = require('posthtml-parser');
-var render = require('posthtml-render');
+var generator = require('posthtml-render');
 
 var api = require('./api.js');
 
@@ -10,12 +10,13 @@ function PostHTML(plugins) {
 }
 
 /**
- * Parse html to json tree
+ * Expose default parser and code generator
  *
  * @param {String} html htmltree
  * @returns {PostHTMLTree} json jsontree
  */
 PostHTML.parse = parser;
+PostHTML.generate = generator;
 
 /**
 * Use plugin
@@ -40,7 +41,8 @@ PostHTML.prototype.use = function() {
  */
 PostHTML.prototype.process = function(tree, options) {
     options = options || {};
-    var parser = options.parser || PostHTML.parse.bind(PostHTML);
+    if (options.parser) parser = options.parser;
+    if (options.generator) generator = options.generator;
     tree = options.skipParse ? tree : parser(tree);
     tree.options = options;
 
@@ -60,7 +62,7 @@ PostHTML.prototype.process = function(tree, options) {
             tree = result || tree;
         });
 
-        return lazyRender(tree);
+        return lazyRender(generator, tree);
     }
 
     // async mode
@@ -115,7 +117,7 @@ PostHTML.prototype.process = function(tree, options) {
     return new Promise(function(resolve, reject) {
         next(tree, function(err, tree) {
             if (err) reject(err);
-            else resolve(lazyRender(tree));
+            else resolve(lazyRender(generator, tree));
         });
     });
 };
@@ -161,10 +163,10 @@ function apiExtend(tree) {
  * @param {PostHTMLTree} tree - json tree to wrap
  * @returns {html: String, tree: PostHTMLTree} - result
  */
-function lazyRender(tree) {
+function lazyRender(generator, tree) {
     return {
         get html() {
-            return render(tree, tree.options);
+            return generator(tree, tree.options);
         },
         tree: tree
     };


### PR DESCRIPTION
First piece is terminology -- while "render" and "stringify" are generic terms that could mean anything, a code generator is a [compiler-specific term](https://www.wikiwand.com/en/Code_generation_(compiler)) that is defined as exactly what we currently are calling the "renderer" is doing. So I figure better to use the technically correct term. Postcss uses "stringifier" instead, probably because it converts an AST to a _string_, but technically, this is still not correct and could confuse people.

Second is just making the code generator configurable. This is for the same reason as you'd make the parser configurable. In this immediate case, I'll use this feature to test a new code generator I'm working on that will generate a function rather than a string, as discussed in #149.

😁 