### PR TITLE
Options

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,10 +6,6 @@
 
 npm-debug.log
 
-CHANGELOG.md
-CONTRIBUTING.md
-MAINTAINERS
-
 # DIRECTORIES
 docs
 test

--- a/lib/index.js
+++ b/lib/index.js
@@ -90,7 +90,7 @@ PostHTML.prototype.process = function (tree, options) {
     render = options.render
   }
 
-  tree = options.skipParse ? tree : parser(tree)
+  tree = typeof tree === 'object' ? tree : parser(tree)
 
   tree.options = options
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -83,8 +83,12 @@ PostHTML.prototype.process = function (tree, options) {
    */
   options = options || {}
 
-  if (options.parser) parser = options.parser
-  if (options.render) render = options.render
+  if (options.parser && typeof options.parser === 'function') {
+    parser = options.parser
+  }
+  if (options.render && typeof options.render === 'function') {
+    render = options.render
+  }
 
   tree = options.skipParse ? tree : parser(tree)
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "processor"
   ],
   "main": "lib",
+  "files": [
+    "lib"
+  ],
   "engines": {
     "node": ">=0.10.0"
   },


### PR DESCRIPTION
### Chore

1. Remove `CHANGELOG.md`, `CONTRIBUTING.md`, `MAINTAINERS` since the would e published regardless of this setup.
2. Add package.files to prevent e.g `logo.svg` publishing, published files are set explicitly now.

### Fix

Check if `options.parser && options.render` are functions, this is a needed fix for `posthtml-load-config`in particular, but should improve stability in general

**posthtml.config.js**
```js
module.exports = (ctx) => ({
  parser: ctx.ext === '.sml' ? 'posthtml-sugarml' : false // <--- 
  // use default parser when false, throws an error at the moment
  ...
})
```

### Refactor 

Check if tree needs/should be parsed 'programmtically' instead of setting an option `options.skipParse` (removed).

```js
options.skipParse = typeof tree === 'object' ? tree : parser(tree)
```

fixes #191 

@voischev @awinogradov @posthtml/collaborators