### PR TITLE
feat(index): add support for `messages` (`result.messages`)

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -82,7 +82,29 @@ module.exports = {
 
         return node
       })
-  }
+  },
+  /**
+   * plugin messages to store and pass metadata
+   *
+   * @memberof tree
+   * @type {Array} messages
+   *
+   ***Usage**
+   * ```js
+   * export default function plugin (options = {}) {
+   *   return function (tree) {
+   *      tree.messages.push({
+   *        type: 'dependency',
+   *        file: 'path/to/dependency.html',
+   *        from: tree.options.from
+   *      })
+   *
+   *      return tree
+   *   }
+   * }
+   * ```
+   */
+  messages: []
 }
 
 /** @private */

--- a/lib/index.js
+++ b/lib/index.js
@@ -236,6 +236,7 @@ function tryCatch (tryFn, catchFn) {
 function apiExtend (tree) {
   tree.walk = api.walk
   tree.match = api.match
+  tree.messages = api.messages
 }
 
 /**
@@ -252,6 +253,7 @@ function lazyResult (render, tree) {
     get html () {
       return render(tree, tree.options)
     },
-    tree: tree
+    tree: tree,
+    messages: tree.messages
   }
 }

--- a/test/messages.js
+++ b/test/messages.js
@@ -1,0 +1,57 @@
+var it = require('mocha').it
+var expect = require('chai').expect
+var describe = require('mocha').describe
+
+var posthtml = require('../lib')
+
+var html = '<div class="messages">Messages</div>'
+var messages = [
+  {
+    type: 'dependency',
+    file: './path/to/1.html',
+    from: undefined
+  },
+  {
+    type: 'dependency',
+    file: './path/to/2.html',
+    from: undefined
+  }
+]
+
+function test (html, done) {
+  posthtml()
+    .use(function (tree) {
+      tree.messages.push({
+        type: 'dependency',
+        file: './path/to/1.html',
+        from: tree.options.from
+      })
+
+      return tree
+    })
+    .use(function (tree) {
+      tree.messages.push({
+        type: 'dependency',
+        file: './path/to/2.html',
+        from: tree.options.from
+      })
+
+      return tree
+    })
+    .process(html)
+    .then(function (result) {
+      expect(html).to.eql(result.html)
+      expect(messages).to.eql(result.messages)
+
+      done()
+    })
+    .catch(function (error) {
+      done(error)
+    })
+}
+
+describe('Messages', function () {
+  it('should expose messages via result.messages', function (done) {
+    test(html, done)
+  })
+})


### PR DESCRIPTION
### `Notable Changes`

This is a simplify version of #195 just adding the surface API necessary to get a messages API going

### `Issues`

- Fixes #147 
- Fixes #189
- Fixes #197 

> ℹ️  This is needed for [`html-loader` #157](https://github.com/webpack-contrib/html-loader/pull/157) (~930,000 downloads/month) to keep track of dependencies