### PR TITLE
fix(index): don't throw on empty tree (`options.skipParse`)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -94,7 +94,9 @@ PostHTML.prototype.process = function (tree, options) {
   if (options.parser) parser = options.parser
   if (options.render) render = options.render
 
-  tree = options.skipParse ? tree : parser(tree, options)
+  tree = options.skipParse
+    ? tree || []
+    : parser(tree, options)
 
   tree.options = options
   tree.processor = this

--- a/test/process.js
+++ b/test/process.js
@@ -1,0 +1,37 @@
+var it = require('mocha').it
+var expect = require('chai').expect
+var describe = require('mocha').describe
+
+var posthtml = require('../lib')
+
+var html = null
+
+function test (html, done) {
+  posthtml()
+    .use(function (tree) {
+      tree.walk(function (node) { return node })
+      tree.match(/(.+)/, function (node) { return node })
+
+      tree.messages.push({
+        type: 'warning',
+        message: 'tree is empty'
+      })
+
+      return tree
+    })
+    .process(html, { skipParse: true })
+    .then(function (result) {
+      expect('').to.eql(result.html)
+
+      done()
+    })
+    .catch(function (error) {
+      done(error)
+    })
+}
+
+describe('Process', function () {
+  it('should not throw on empty tree', function (done) {
+    test(html, done)
+  })
+})


### PR DESCRIPTION
### `Issues`

- Fixes #244 