### PR TITLE
[WIP] feat(index): add `parser` options `{Object}` (`options.parser`)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -105,12 +105,30 @@ class PostHTML {
     */
     options = options || {}
 
-    if (options.parser) parser = options.parser
-    if (options.render) render = options.render
+    if (options.parser) {
+      if (typeof options.parser === 'object') {
+        parser = parser(options.parser)
+      }
+
+      if (typeof options.parser === 'function') {
+        parser = options.parser
+      }
+    }
+    // else {
+      // TODO(michael-ciniawsky)
+      // Call parser() with defaults here, when curried
+      // parser = parser
+    // }
+
+    if (options.render) {
+      if (typeof options.render === 'function') {
+        render = options.render
+      }
+    }
 
     tree = options.skipParse
       ? tree
-      : parser(tree, options)
+      : parser(tree)
 
     tree.options = options
     tree.processor = this


### PR DESCRIPTION
### `Notable Changes`

- Adds support to pass `options` to the default parser (HTML) `{Object}`

### `Issues`

- None

### `BREAKING CHANGES`

- The `posthtml-parser` API needs to be curried for this to work ([#21](https://github.com/posthtml/posthtml-parser/pull/21))

```js
const parser = require('posthtml-parser')
// From
const tree = parser(html, options)
// To
const tree = parser(options)(html)
```
