### PR TITLE
fix(grunt): working Grunt repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Check [project-stub](https://github.com/posthtml/project-stub) for an example wi
 ### [Grunt](https://gruntjs.com)
 
 ```bash
-npm i -D grunt-posthtml
+npm i -D grunt-juwain-posthtml
 ```
 
 ```js


### PR DESCRIPTION
### Summary

I replace [**non-working package**](https://github.com/TCotton/grunt-posthtml/issues/3) to [**fork**](https://www.npmjs.com/package/grunt-juwain-posthtml), that successful works on my machine.

Thanks.