### PR TITLE
ISSUE-324: correctly export namespace & function

### DIFF
--- a/types/posthtml.d.ts
+++ b/types/posthtml.d.ts
@@ -1,7 +1,7 @@
 type Maybe<T> = void | T;
 type MaybeArray<T> = T | T[];
 
-export namespace PostHTML {
+declare namespace PostHTML {
   type StringMatcher = string | RegExp;
   type AttrMatcher = Record<string, StringMatcher>;
   type ContentMatcher =
@@ -100,6 +100,8 @@ export namespace PostHTML {
   }
 }
 
-export default function posthtml<TThis, TMessage>(
+declare function PostHTML<TThis, TMessage>(
   plugins?: PostHTML.Plugin<TThis>[]
 ): PostHTML.PostHTML<TThis, TMessage>;
+
+export = PostHTML;


### PR DESCRIPTION
### `Notable Changes`

As noted @CodingDoug, our types are incorrect for standard use in TS (without `allowSyntheticDefaultImports`, `esModuleInterop`). Since there is no `default` export in the main module of this package, we should not declare it in types.

#### `Commit Message Summary (CHANGELOG)`

```
Fixed export of types for package.
```

### `Type`

> ℹ️  What types of changes does your code introduce?

- [x] Fix

### `SemVer`

> ℹ️  What changes to the current `semver` range does your PR introduce?

- [x] Fix (:label: Patch)

### `Issues`

> ℹ️ What issue(s) (if any) are closed by your PR?

- Fixes `#324`

### `Checklist`

> ℹ️  You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is a reminder of what we are going to look for before merging your code.

> 👉  _Put an `x` in the boxes that apply and delete all others._

- [ ] Lint and unit tests pass with my changes
- [ ] I have added tests that prove my fix is effective/works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes are merged and published in downstream modules
