### PR TITLE
refactor: migrate to ES6

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -80,14 +80,14 @@ function walk (cb) {
  */
 function match (expression, cb) {
   return Array.isArray(expression)
-    ? traverse(this, function (node) {
-      for (var i = 0; i < expression.length; i++) {
+    ? traverse(this, node => {
+      for (let i = 0; i < expression.length; i++) {
         if (compare(expression[i], node)) return cb(node)
       }
 
       return node
     })
-    : traverse(this, function (node) {
+    : traverse(this, node => {
       if (compare(expression, node)) return cb(node)
 
       return node
@@ -101,7 +101,7 @@ module.exports.walk = walk
 /** @private */
 function traverse (tree, cb) {
   if (Array.isArray(tree)) {
-    for (var i = 0; i < tree.length; i++) {
+    for (let i = 0; i < tree.length; i++) {
       tree[i] = traverse(cb(tree[i]), cb)
     }
   } else if (
@@ -126,16 +126,12 @@ function compare (expected, actual) {
   }
 
   if (Array.isArray(expected)) {
-    return expected.every(function (exp) {
-      return [].some.call(actual, function (act) {
-        return compare(exp, act)
-      })
-    })
+    return expected.every(exp => [].some.call(actual, act => compare(exp, act)))
   }
 
-  return Object.keys(expected).every(function (key) {
-    var ao = actual[key]
-    var eo = expected[key]
+  return Object.keys(expected).every(key => {
+    const ao = actual[key]
+    const eo = expected[key]
 
     if (typeof eo === 'object' && eo !== null && ao !== null) {
       return compare(eo, ao)

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,8 @@
-var pkg = require('../package.json')
-var Api = require('./api.js')
+const pkg = require('../package.json')
+const Api = require('./api.js')
 
-var parser = require('posthtml-parser')
-var render = require('posthtml-render')
+let parser = require('posthtml-parser')
+let render = require('posthtml-render')
 
 /**
  * @author Ivan Voischev (@voischev),
@@ -15,229 +15,230 @@ var render = require('posthtml-render')
  * @constructor PostHTML
  * @param {Array} plugins - An array of PostHTML plugins
  */
-function PostHTML (plugins) {
-/**
- * PostHTML Instance
- *
- * @prop plugins
- * @prop options
- */
-  this.version = pkg.version
-  this.name = pkg.name
-  this.plugins = typeof plugins === 'function' ? [plugins] : plugins || []
-  this.source = ''
-
+class PostHTML {
+  constructor (plugins) {
   /**
-   * Tree messages to store and pass metadata between plugins
+   * PostHTML Instance
    *
-   * @memberof tree
-   * @type {Array} messages
-   *
-   * @example
-   * ```js
-   * export default function plugin (options = {}) {
-   *   return function (tree) {
-   *      tree.messages.push({
-   *        type: 'dependency',
-   *        file: 'path/to/dependency.html',
-   *        from: tree.options.from
-   *      })
-   *
-   *      return tree
-   *   }
-   * }
-   * ```
+   * @prop plugins
+   * @prop options
    */
-  this.messages = []
+    this.version = pkg.version
+    this.name = pkg.name
+    this.plugins = typeof plugins === 'function' ? [plugins] : plugins || []
+    this.source = ''
 
-  /**
-   * Tree method parsing string inside plugins.
-   *
-   * @memberof tree
-   * @type {Function} parser
-   *
-   * @example
-   * ```js
-   * export default function plugin (options = {}) {
-   *   return function (tree) {
-   *      tree.match({ tag: 'include' }, function(node) {
-   *          node.tag = false;
-   *          node.content = tree.parser(fs.readFileSync(node.attr.src))
-   *          return node
-   *      })
-   *
-   *      return tree
-   *   }
-   * }
-   * ```
-   */
-  this.parser = parser
+    /**
+     * Tree messages to store and pass metadata between plugins
+     *
+     * @memberof tree
+     * @type {Array} messages
+     *
+     * @example
+     * ```js
+     * export default function plugin (options = {}) {
+     *   return function (tree) {
+     *      tree.messages.push({
+     *        type: 'dependency',
+     *        file: 'path/to/dependency.html',
+     *        from: tree.options.from
+     *      })
+     *
+     *      return tree
+     *   }
+     * }
+     * ```
+     */
+    this.messages = []
 
-  /**
-   * Tree method rendering tree to string inside plugins.
-   *
-   * @memberof tree
-   * @type {Function} render
-   *
-   * @example
-   * ```js
-   * export default function plugin (options = {}) {
-   *    return function (tree) {
-   *      var outherTree = ['\n', {tag: 'div', content: ['1']}, '\n\t', {tag: 'div', content: ['2']}, '\n'];
-   *      var htmlWitchoutSpaceless = tree.render(outherTree).replace(/[\n|\t]/g, '');
-   *      return tree.parser(htmlWitchoutSpaceless)
-   *    }
-   * }
-   * ```
-   */
-  this.render = render
+    /**
+     * Tree method parsing string inside plugins.
+     *
+     * @memberof tree
+     * @type {Function} parser
+     *
+     * @example
+     * ```js
+     * export default function plugin (options = {}) {
+     *   return function (tree) {
+     *      tree.match({ tag: 'include' }, function(node) {
+     *          node.tag = false;
+     *          node.content = tree.parser(fs.readFileSync(node.attr.src))
+     *          return node
+     *      })
+     *
+     *      return tree
+     *   }
+     * }
+     * ```
+     */
+    this.parser = parser
 
-  // extend api methods
-  Api.call(this)
-}
+    /**
+     * Tree method rendering tree to string inside plugins.
+     *
+     * @memberof tree
+     * @type {Function} render
+     *
+     * @example
+     * ```js
+     * export default function plugin (options = {}) {
+     *    return function (tree) {
+     *      var outherTree = ['\n', {tag: 'div', content: ['1']}, '\n\t', {tag: 'div', content: ['2']}, '\n'];
+     *      var htmlWitchoutSpaceless = tree.render(outherTree).replace(/[\n|\t]/g, '');
+     *      return tree.parser(htmlWitchoutSpaceless)
+     *    }
+     * }
+     * ```
+     */
+    this.render = render
 
-/**
-* @this posthtml
-* @param   {Function} plugin - A PostHTML plugin
-* @returns {Constructor} - this(PostHTML)
-*
-* **Usage**
-* ```js
-* ph.use((tree) => { tag: 'div', content: tree })
-*   .process('<html>..</html>', {})
-*   .then((result) => result))
-* ```
-*/
-PostHTML.prototype.use = function () {
-  [].push.apply(this.plugins, arguments)
-  return this
-}
-
-/**
- * @param   {String} html - Input (HTML)
- * @param   {?Object} options - PostHTML Options
- * @returns {Object<{html: String, tree: PostHTMLTree}>} - Sync Mode
- * @returns {Promise<{html: String, tree: PostHTMLTree}>} - Async Mode (default)
- *
- * **Usage**
- *
- * **Sync**
- * ```js
- * ph.process('<html>..</html>', { sync: true }).html
- * ```
- *
- * **Async**
- * ```js
- * ph.process('<html>..</html>', {}).then((result) => result))
- * ```
- */
-PostHTML.prototype.process = function (tree, options) {
-  /**
-   * ## PostHTML Options
-   *
-   * @type {Object}
-   * @prop {?Boolean} options.sync - enables sync mode, plugins will run synchronously, throws an error when used with async plugins
-   * @prop {?Function} options.parser - use custom parser, replaces default (posthtml-parser)
-   * @prop {?Function} options.render - use custom render, replaces default (posthtml-render)
-   * @prop {?Boolean} options.skipParse - disable parsing
-   * @prop {?Array} options.directives - Adds processing of custom [directives](https://github.com/posthtml/posthtml-parser#directives).
-   */
-  options = this.options = options || {}
-  this.source = tree
-
-  if (options.parser) parser = this.parser = options.parser
-  if (options.render) render = this.render = options.render
-
-  tree = options.skipParse
-    ? tree || []
-    : parser(tree, options)
-
-  // sync mode
-  if (options.sync === true) {
-    this.plugins.forEach(function (plugin, index) {
-      _treeExtendApi(tree, this)
-
-      var result
-
-      if (plugin.length === 2 || isPromise(result = plugin(tree))) {
-        throw new Error(
-          'Can’t process contents in sync mode because of async plugin: ' + plugin.name
-        )
-      }
-
-      // clearing the tree of options
-      if (index !== this.plugins.length - 1 && !options.skipParse) {
-        tree = [].concat(tree)
-      }
-
-      // return the previous tree unless result is fulfilled
-      tree = result || tree
-    }.bind(this))
-
-    return lazyResult(render, tree)
+    // extend api methods
+    Api.call(this)
   }
 
-  // async mode
-  var i = 0
+  /**
+  * @this posthtml
+  * @param   {Function} plugin - A PostHTML plugin
+  * @returns {Constructor} - this(PostHTML)
+  *
+  * **Usage**
+  * ```js
+  * ph.use((tree) => { tag: 'div', content: tree })
+  *   .process('<html>..</html>', {})
+  *   .then((result) => result))
+  * ```
+  */
+  use (...args) {
+    this.plugins.push(...args)
 
-  var next = function (result, cb) {
-    _treeExtendApi(result, this)
+    return this
+  }
 
-    // all plugins called
-    if (this.plugins.length <= i) {
-      cb(null, result)
-      return
+  /**
+   * @param   {String} html - Input (HTML)
+   * @param   {?Object} options - PostHTML Options
+   * @returns {Object<{html: String, tree: PostHTMLTree}>} - Sync Mode
+   * @returns {Promise<{html: String, tree: PostHTMLTree}>} - Async Mode (default)
+   *
+   * **Usage**
+   *
+   * **Sync**
+   * ```js
+   * ph.process('<html>..</html>', { sync: true }).html
+   * ```
+   *
+   * **Async**
+   * ```js
+   * ph.process('<html>..</html>', {}).then((result) => result))
+   * ```
+   */
+  process (tree, options = {}) {
+    /**
+     * ## PostHTML Options
+     *
+     * @type {Object}
+     * @prop {?Boolean} options.sync - enables sync mode, plugins will run synchronously, throws an error when used with async plugins
+     * @prop {?Function} options.parser - use custom parser, replaces default (posthtml-parser)
+     * @prop {?Function} options.render - use custom render, replaces default (posthtml-render)
+     * @prop {?Boolean} options.skipParse - disable parsing
+     * @prop {?Array} options.directives - Adds processing of custom [directives](https://github.com/posthtml/posthtml-parser#directives).
+     */
+    this.options = options
+    this.source = tree
+
+    if (options.parser) parser = this.parser = options.parser
+    if (options.render) render = this.render = options.render
+
+    tree = options.skipParse
+      ? tree || []
+      : parser(tree, options)
+
+    // sync mode
+    if (options.sync === true) {
+      this.plugins.forEach((plugin, index) => {
+        _treeExtendApi(tree, this)
+
+        let result
+
+        if (plugin.length === 2 || isPromise(result = plugin(tree))) {
+          throw new Error(
+            `Can’t process contents in sync mode because of async plugin: ${plugin.name}`
+          )
+        }
+
+        // clearing the tree of options
+        if (index !== this.plugins.length - 1 && !options.skipParse) {
+          tree = [].concat(tree)
+        }
+
+        // return the previous tree unless result is fulfilled
+        tree = result || tree
+      })
+
+      return lazyResult(render, tree)
     }
 
-    // little helper to go to the next iteration
-    function _next (res) {
-      if (res && !options.skipParse) {
-        res = [].concat(res)
+    // async mode
+    let i = 0
+
+    const next = (result, cb) => {
+      _treeExtendApi(result, this)
+
+      // all plugins called
+      if (this.plugins.length <= i) {
+        cb(null, result)
+        return
       }
 
-      return next(res || result, cb)
-    }
+      // little helper to go to the next iteration
+      function _next (res) {
+        if (res && !options.skipParse) {
+          res = [].concat(res)
+        }
 
-    // call next
-    var plugin = this.plugins[i++]
+        return next(res || result, cb)
+      }
 
-    if (plugin.length === 2) {
-      plugin(result, function (err, res) {
-        if (err) return cb(err)
-        _next(res)
+      // call next
+      const plugin = this.plugins[i++]
+
+      if (plugin.length === 2) {
+        plugin(result, (err, res) => {
+          if (err) return cb(err)
+          _next(res)
+        })
+        return
+      }
+
+      // sync and promised plugins
+      let err = null
+
+      const res = tryCatch(() => plugin(result), e => {
+        err = e
+        return e
       })
-      return
+
+      if (err) {
+        cb(err)
+        return
+      }
+
+      if (isPromise(res)) {
+        res.then(_next).catch(cb)
+        return
+      }
+
+      _next(res)
     }
 
-    // sync and promised plugins
-    var err = null
-
-    var res = tryCatch(function () {
-      return plugin(result)
-    }, function (e) {
-      err = e
-      return e
+    return new Promise((resolve, reject) => {
+      next(tree, (err, tree) => {
+        if (err) reject(err)
+        else resolve(lazyResult(render, tree))
+      })
     })
-
-    if (err) {
-      cb(err)
-      return
-    }
-
-    if (isPromise(res)) {
-      res.then(_next).catch(cb)
-      return
-    }
-
-    _next(res)
-  }.bind(this)
-
-  return new Promise(function (resolve, reject) {
-    next(tree, function (err, tree) {
-      if (err) reject(err)
-      else resolve(lazyResult(render, tree))
-    })
-  })
+  }
 }
 
 /**
@@ -254,9 +255,7 @@ PostHTML.prototype.process = function (tree, options) {
  * const ph = posthtml([ plugin() ])
  * ```
  */
-module.exports = function (plugins) {
-  return new PostHTML(plugins)
-}
+module.exports = plugins => new PostHTML(plugins)
 
 /**
  * Extension of options tree
@@ -316,7 +315,7 @@ function lazyResult (render, tree) {
     get html () {
       return render(tree, tree.options)
     },
-    tree: tree,
+    tree,
     messages: tree.messages
   }
 }


### PR DESCRIPTION
### `Notable Changes`

Migrate to ES6.

https://github.com/posthtml/posthtml/blob/acc430df7353cfe31e173ce43f28af6ce79941ff/package.json#L22-L24

PostHTML is always dropping old Node.js version even it is still compatible. So why don't we embrace the new JavaScript syntax?

The migration for the unit test will be updated in another PR.

#### `Commit Message Summary (CHANGELOG)`

```
refactor: migrate to ES6
```

### `Type`

> ℹ️  What types of changes does your code introduce?

> 👉 _Put an `x` in the boxes that apply and delete all others_

- [ ] CI
- [ ] Fix
- [ ] Perf
- [ ] Docs
- [ ] Test
- [ ] Chore
- [ ] Style
- [ ] Build
- [ ] Feature
- [x] Refactor

### `SemVer`

> ℹ️  What changes to the current `semver` range does your PR introduce?

> 👉  _Put an `x` in the boxes that apply and delete all others_

- [ ] Fix (:label: Patch)
- [ ] Feature (:label: Minor)
- [ ] Breaking Change (:label: Major)

No API changes, no bugs fixed. However, the PR should be considered as a refactoring.

### `Checklist`

> ℹ️  You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is a reminder of what we are going to look for before merging your code.

> 👉  _Put an `x` in the boxes that apply and delete all others._

- [x] Lint and unit tests pass with my changes
- [ ] I have added tests that prove my fix is effective/works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes are merged and published in downstream modules
