### PR TITLE
build: update dependencies

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 const pkg = require('../package.json')
 const Api = require('./api.js')
 
-let parser = require('posthtml-parser')
+let { default: parser } = require('posthtml-parser')
 let render = require('posthtml-render')
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1547,36 +1547,36 @@
       }
     },
     "dom-serializer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.1.0.tgz",
-      "integrity": "sha512-ox7bvGXt2n+uLWtCRLybYx60IrOlWL/aCebWJk1T0d4m3y2tzf4U3ij9wBMUb6YJZpz06HCCYuyCDveE2xXmzQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.1.tgz",
+      "integrity": "sha512-Pv2ZluG5ife96udGgEDovOOOA5UELkltfJpnIExPrAk1LTvecolUGn6lIaoLh86d83GiB86CjzciMd9BuRB71Q==",
       "requires": {
         "domelementtype": "^2.0.1",
-        "domhandler": "^3.0.0",
+        "domhandler": "^4.0.0",
         "entities": "^2.0.0"
       }
     },
     "domelementtype": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.2.tgz",
-      "integrity": "sha512-wFwTwCVebUrMgGeAwRL/NhZtHAUyT9n9yg4IMDwf10+6iCMxSkVq9MGCVEH+QZWo1nNidy8kNvwmv4zWHDTqvA=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
     },
     "domhandler": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz",
-      "integrity": "sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.1.0.tgz",
+      "integrity": "sha512-/6/kmsGlMY4Tup/nGVutdrK9yQi4YjWVcVeoQmixpzjOUK1U7pQkvAPHBJeUxOgxF0J8f8lwCJSlCfD0V4CMGQ==",
       "requires": {
-        "domelementtype": "^2.0.1"
+        "domelementtype": "^2.2.0"
       }
     },
     "domutils": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.4.2.tgz",
-      "integrity": "sha512-NKbgaM8ZJOecTZsIzW5gSuplsX2IWW2mIK7xVr8hTQF2v1CJWTmLZ1HOCh5sH+IzVPAGE5IucooOkvwBRAdowA==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.5.2.tgz",
+      "integrity": "sha512-MHTthCb1zj8f1GVfRpeZUbohQf/HdBos0oX5gZcQFepOZPLLRyj6Wn7XS7EMnY7CVpwv8863u2vyE83Hfu28HQ==",
       "requires": {
         "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.0.1",
-        "domhandler": "^3.3.0"
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.1.0"
       }
     },
     "dot-prop": {
@@ -2843,13 +2843,13 @@
       "dev": true
     },
     "htmlparser2": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-5.0.1.tgz",
-      "integrity": "sha512-vKZZra6CSe9qsJzh0BjBGXo8dvzNsq/oGvsjfRdOrrryfeD9UOBEEQdeoqCRmKZchF5h2zOBMQ6YuQ0uRUmdbQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
       "requires": {
         "domelementtype": "^2.0.1",
-        "domhandler": "^3.3.0",
-        "domutils": "^2.4.2",
+        "domhandler": "^4.0.0",
+        "domutils": "^2.5.2",
         "entities": "^2.0.0"
       }
     },
@@ -4458,11 +4458,11 @@
       }
     },
     "posthtml-parser": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.6.0.tgz",
-      "integrity": "sha512-5ffwKQNgtVHdhZniWxu+1ryvaZv5l25HPLUV6W5xy5nYVWMXtvjtwRnbSpfbKFvbyl7XI+d4AqkjmonkREqnXA==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.7.2.tgz",
+      "integrity": "sha512-LjEEG/3fNcWZtBfsOE3Gbyg1Li4CmsZRkH1UmbMR7nKdMXVMYI3B4/ZMiCpaq8aI1Aym4FRMMW9SAOLSwOnNsQ==",
       "requires": {
-        "htmlparser2": "^5.0.1"
+        "htmlparser2": "^6.0.0"
       }
     },
     "posthtml-render": {

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "node": ">=10.0.0"
   },
   "dependencies": {
-    "posthtml-parser": "^0.6.0",
-    "posthtml-render": "^1.2.3"
+    "posthtml-parser": "^0.7.2",
+    "posthtml-render": "^1.3.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",

--- a/test/parser.js
+++ b/test/parser.js
@@ -4,7 +4,7 @@ const path = require('path')
 const { it, describe } = require('mocha')
 const { expect } = require('chai')
 
-const parser = require('posthtml-parser')
+const { default: parser } = require('posthtml-parser')
 const render = require('posthtml-render')
 
 const html = readFileSync(


### PR DESCRIPTION
@Scrum thanks for making a new release of posthtml-parser 😃 

This PR makes posthtml use the latest versions of posthtml-parser and posthml-render. Since posthtml-parser version 0.7 changed the way the parser function is exported (a side effect of the typescript rewrite I think), I've fixed the imports in posthtml accordingly.