### PR TITLE
Remove david-dm from README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,4 @@
 [![NPM][npm]][npm-url]
-[![Deps][deps]][deps-url]
 [![Tests][build]][build-url]
 [![Coverage][cover]][cover-url]
 [![Standard Code Style][code-style]][code-style-url]
@@ -391,9 +390,6 @@ Thank you to all our backers! 🙏 [[Become a backer](https://opencollective.com
 
 [npm]: https://img.shields.io/npm/v/posthtml.svg
 [npm-url]: https://npmjs.com/package/posthtml
-
-[deps]: https://david-dm.org/posthtml/posthtml.svg
-[deps-url]: https://david-dm.org/posthtml/posthtml
 
 [build]: https://github.com/posthtml/posthtml/workflows/Actions%20Status/badge.svg?style=flat-square
 [build-url]: https://github.com/posthtml/posthtml/actions?query=workflow%3A%22CI+tests%22


### PR DESCRIPTION
The `david-dm.org` website is down for 3 months, and the project `alanshaw/david` is not actively maintained anymore. `david-dm.org` should be considered dead, thus badges should be removed from README.