### PR TITLE
Match tag name using regex

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -116,7 +116,13 @@ function traverse (tree, cb) {
 /** @private */
 function compare (expected, actual) {
   if (expected instanceof RegExp) {
-    if (typeof actual === 'object') return false
+    if (typeof actual === 'object') {
+      if (typeof actual.tag === 'string')
+        return expected.test(actual.tag)
+
+      return false
+    }
+    
     if (typeof actual === 'string') return expected.test(actual)
   }
 


### PR DESCRIPTION
I didn't find a way to match tag name using regex.

With this change we can do something like:

```js
tree.match(new RegExp('^x-', 'i'), node => {
  // node.tag start with "x-"
})
```

Maybe there is another way to do this, but I didn't find.

I need this feature for another change in posthtml-modules which I will do separately.